### PR TITLE
Axml parsing - phase out apktool.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,4 +15,3 @@ macos-dmg/QuestPatcher.dmg
 # IDE Directories
 .vs/
 .idea/
-

--- a/QuestPatcher.Axml/AttributeType.cs
+++ b/QuestPatcher.Axml/AttributeType.cs
@@ -1,0 +1,11 @@
+﻿namespace QuestPatcher.Axml
+{
+    internal enum AttributeType
+    {
+        FirstInt = 0x10,
+        Boolean = 0x12,
+        Hex = 0x11,
+        Reference = 0x01,
+        String = 0x03
+    }
+}

--- a/QuestPatcher.Axml/AxmlAttribute.cs
+++ b/QuestPatcher.Axml/AxmlAttribute.cs
@@ -1,0 +1,129 @@
+﻿using System;
+using System.Diagnostics;
+using System.IO;
+
+namespace QuestPatcher.Axml
+{
+    public class AxmlAttribute
+    {
+        /// <summary>
+        /// Name of the attribute
+        /// </summary>
+        public string Name { get; set; }
+
+        /// <summary>
+        /// Uri of the namespace of this attribute
+        /// <code>null</code> if it isn't in a namespace.
+        /// </summary>
+        public Uri? Namespace { get; set; }
+
+        /// <summary>
+        /// Resource ID of this attribute's value.
+        /// This may refer to a resource inside the APK or is just a constant in cases like debuggable and legacyStorageSupport attributes.
+        /// <code>null</code> if parsed resource ID index was <code>-1</code>
+        /// </summary>
+        public int? ResourceId { get; set; }
+
+        /// <summary>
+        /// The value of the attribute.
+        /// May be <see cref="string" /> or <see cref="WrappedValue" />.
+        /// </summary>
+        /// <exception cref="InvalidOperationException"></exception>
+        public object Value
+        {
+            get => _value;
+            set
+            {
+                if (value is string)
+                {
+                    _valueType = AttributeType.String;
+                }   else if (value is WrappedValue)
+                {
+                    _valueType = null;
+                }   else if (value is bool)
+                {
+                    _valueType = AttributeType.Boolean;
+                }   else if (value is int)
+                {
+                    _valueType = AttributeType.FirstInt;
+                }
+                else
+                {
+                    throw new InvalidOperationException(
+                        $"Cannot set value of axml attribute to type of {value.GetType().Name}: must be {nameof(WrappedValue)} or string");
+                }
+
+                _value = value;
+            }
+        }
+
+        private object _value;
+        private AttributeType? _valueType;
+
+        internal AxmlAttribute(string name, Uri? ns, int? resourceId, object value, AttributeType valueType)
+        {
+            Name = name;
+            Namespace = ns;
+            ResourceId = resourceId;
+            Value = value;
+            _valueType = valueType;
+            Debug.Assert(_value != null);
+        }
+
+        public AxmlAttribute(string name, Uri? ns, int? resourceId, object value)
+        {
+            Name = name;
+            Namespace = ns;
+            ResourceId = resourceId;
+            Value = value;
+            Debug.Assert(_value != null);
+        }
+
+        internal void PrepareResourceIndices(SavingContext ctx)
+        {
+            if (ResourceId != null)
+            {
+                ctx.ResourcePool.GetIndex((int) ResourceId);
+                ctx.StringPool.GetIndex(Name);
+            }
+        }
+
+        internal void Save(SavingContext ctx)
+        {
+            ctx.Writer.Write(Namespace == null ? -1 : ctx.StringPool.GetIndex(Namespace.ToString()));
+            int nameIndex = ctx.StringPool.GetIndex(Name);
+            int resourceIdIndex = ResourceId == null ? -1 : ctx.ResourcePool.GetIndex((int) ResourceId);
+            if (ResourceId != null && nameIndex != resourceIdIndex)
+            {
+                throw new InvalidDataException("Name indices and resource indices for attributes must be explicitly matched before saving. They did not match, therefore this step was not completed");
+            }
+            ctx.Writer.Write(nameIndex);
+
+            int rawStringIndex = -1;
+            int type = _valueType == null ? -1 : ((int) _valueType << 24) | 0x000008;
+            int rawValue;
+            if (Value is WrappedValue)
+            {
+                WrappedValue wrappedValue = (WrappedValue) Value;
+                rawStringIndex = ctx.StringPool.GetIndex(wrappedValue.RawValue);
+                rawValue = wrappedValue.ReferenceId;
+            }
+            else if (Value is bool)
+            {
+                rawValue = (bool) Value ? 1 : 0;
+            }   else if (Value is string)
+            {
+                rawValue = ctx.StringPool.GetIndex((string) Value);
+                rawStringIndex = rawValue;
+            }
+            else
+            {
+                rawValue = (int) Value;
+            }
+
+            ctx.Writer.Write(rawStringIndex);
+            ctx.Writer.Write(type);
+            ctx.Writer.Write(rawValue);
+        }
+    }
+}

--- a/QuestPatcher.Axml/AxmlElement.cs
+++ b/QuestPatcher.Axml/AxmlElement.cs
@@ -1,0 +1,144 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace QuestPatcher.Axml
+{
+    public class AxmlElement
+    {
+        /// <summary>
+        /// Axml text line number read from the parser.
+        /// TODO: Figure out what we can actually do with this, I'm not sure why it's there.
+        /// </summary>
+        public int TextLineNumber { get; set; }
+
+        /// <summary>
+        /// Attributes of this element.
+        /// </summary>
+        public List<AxmlAttribute> Attributes { get; } = new();
+
+        /// <summary>
+        /// Child elements of this element
+        /// </summary>
+        public List<AxmlElement> Children { get; } = new();
+
+        /// <summary>
+        /// Any namespace declared within this element.
+        /// Keys are namespace prefixes, values are URIs.
+        /// </summary>
+        public Dictionary<string, Uri> DeclaredNamespaces { get; } = new();
+
+        /// <summary>
+        /// The URI of a namespace declared as the default namespace for this element and all child elements
+        /// </summary>
+        public Uri? DeclaredDefaultNamespace { get; set; }
+
+        /// <summary>
+        /// The name of the element, not including the namespace prefix
+        /// </summary>
+        public string Name { get; set; }
+
+        /// <summary>
+        /// The URI of the namespace in the name of the element.
+        /// </summary>
+        public Uri? NamespaceUri { get; set; }
+
+        public AxmlElement(int textLineNumber, string name, Uri? namespaceUri)
+        {
+            TextLineNumber = textLineNumber;
+            Name = name;
+            NamespaceUri = namespaceUri;
+        }
+
+        internal void PrepareResourceIndices(SavingContext ctx)
+        {
+            foreach (AxmlAttribute attribute in Attributes)
+            {
+                attribute.PrepareResourceIndices(ctx);
+            }
+
+            foreach (AxmlElement element in Children)
+            {
+                element.PrepareResourceIndices(ctx);
+            }
+        }
+
+        internal void Save(SavingContext ctx)
+        {
+            // First we need to write the namespaces declared within this element
+            foreach (KeyValuePair<string, Uri> pair in DeclaredNamespaces)
+            {
+                ctx.Writer.WriteChunkHeader(ResourceType.XmlStartNamespace, 16); // Each namespace tag is 3 integers, so 3 * 4 = 12 bytes
+                ctx.Writer.Write(TextLineNumber);
+                ctx.Writer.Write(0xFFFFFFFF);
+                ctx.Writer.Write(ctx.StringPool.GetIndex(pair.Key));
+                ctx.Writer.Write(ctx.StringPool.GetIndex(pair.Value.ToString()));
+            }
+
+            ctx.Writer.WriteChunkHeader(ResourceType.XmlStartElement, 28 + 20 * Attributes.Count); // Each attribute is 5 integers, so 5 * 4 = 20 bytes of the tag
+            ctx.Writer.Write(TextLineNumber);
+            ctx.Writer.Write(0xFFFFFFFF);
+            ctx.Writer.Write(NamespaceUri == null ? -1 : ctx.StringPool.GetIndex(NamespaceUri.ToString()));
+            ctx.Writer.Write(ctx.StringPool.GetIndex(Name));
+            ctx.Writer.Write(0x00140014);
+
+            // Find the ID, class and style attribute indices if they exist
+            short idAttributeIndex = -1;
+            short classAttributeIndex = -1;
+            short styleAttributeIndex = -1;
+            for (short i = 0; i < Attributes.Count; i++)
+            {
+                WrappedValue? wrappedValue = Attributes[i].Value as WrappedValue;
+                if(wrappedValue == null) { continue; }
+
+                // Make sure to prevent multiple of these attributes, as this will save incorrectly
+                switch (wrappedValue.Type)
+                {
+                    case WrappedValueType.Id:
+                        if (idAttributeIndex != -1) { throw new InvalidDataException("Cannot have multiple ID attributes on one element"); }
+                        idAttributeIndex = i;
+                        break;
+                    case WrappedValueType.Class:
+                        if (classAttributeIndex != -1) { throw new InvalidDataException("Cannot have multiple class attributes on one element"); }
+                        classAttributeIndex = i;
+                        break;
+                    case WrappedValueType.Style:
+                        if (styleAttributeIndex != -1) { throw new InvalidDataException("Cannot have multiple style attributes on one element"); }
+                        styleAttributeIndex = i;
+                        break;
+                }
+            }
+            
+            ctx.Writer.Write((short) Attributes.Count);
+            // Stored indices are one above the actual ones
+            ctx.Writer.Write((short) (idAttributeIndex + 1));
+            ctx.Writer.Write((short) (classAttributeIndex + 1));
+            ctx.Writer.Write((short) (styleAttributeIndex + 1));
+            foreach(AxmlAttribute attribute in Attributes)
+            {
+                attribute.Save(ctx);
+            }
+
+            foreach (AxmlElement child in Children)
+            {
+                child.Save(ctx);
+            }
+            ctx.Writer.WriteChunkHeader(ResourceType.XmlEndElement, 16);
+            ctx.Writer.Write(-1);
+            ctx.Writer.Write(0xFFFFFFFF);
+            ctx.Writer.Write(NamespaceUri == null ? -1 : ctx.StringPool.GetIndex(NamespaceUri.ToString()));
+            ctx.Writer.Write(ctx.StringPool.GetIndex(Name));
+            
+            // End the namespaces stated by this element, as we have exited it
+            foreach (KeyValuePair<string, Uri> pair in DeclaredNamespaces.Reverse())
+            {
+                ctx.Writer.WriteChunkHeader(ResourceType.XmlEndNamespace, 16); // Each namespace tag is 3 integers, so 3 * 4 = 12 bytes
+                ctx.Writer.Write(TextLineNumber);
+                ctx.Writer.Write(0xFFFFFFFF);
+                ctx.Writer.Write(ctx.StringPool.GetIndex(pair.Key));
+                ctx.Writer.Write(ctx.StringPool.GetIndex(pair.Value.ToString()));
+            }
+        }
+    }
+}

--- a/QuestPatcher.Axml/AxmlLoader.cs
+++ b/QuestPatcher.Axml/AxmlLoader.cs
@@ -1,0 +1,253 @@
+﻿using System;
+using System.Diagnostics;
+using System.IO;
+using System.Collections.Generic;
+
+namespace QuestPatcher.Axml
+{
+    public static class AxmlLoader
+    {
+        private struct QueuedNamespace
+        {
+            public string? Prefix { get; }
+            public Uri Uri { get; }
+
+            public QueuedNamespace(string? prefix, Uri uri)
+            {
+                Prefix = prefix;
+                Uri = uri;
+            }
+        }
+        
+        public static AxmlElement LoadDocument(Stream stream)
+        {
+            if (!stream.CanSeek)
+            {
+                throw new ArgumentException("Cannot read axml from non-seekable stream");
+            }
+
+            BinaryReader input = new(stream);
+            if (input.ReadResourceType() != ResourceType.Xml)
+            {
+                throw new AxmlParseException("Initial tag was not xml");
+            }
+
+            int fileSize = input.ReadInt32();
+
+            string[]? stringPool = null;
+            int[]? resourceMap = null;
+
+            Stack<AxmlElement> elementStack = new();
+            List<QueuedNamespace> queuedNamespaces = new();
+            AxmlElement? rootElement = null;
+            
+            int preChunkPosition = 8; // Already gone past two ints for initial XML tag and file size
+            while(preChunkPosition < fileSize)
+            {
+                ResourceType chunkType = input.ReadResourceType();
+                int chunkLength = input.ReadInt32();
+
+                if (stringPool == null && chunkType != ResourceType.StringPool)
+                {
+                    throw new AxmlParseException("String pool must be located after Xml tag");
+                }
+
+
+                int currentLineNumber;
+                switch (chunkType)
+                {
+                    // The string pool must come before any elements, a check for this is above
+                    case ResourceType.StringPool:
+                        stringPool = StringPool.LoadStringPool(input);
+                        break;
+                    case ResourceType.XmlResourceMap:
+                        // Divide by 4 because the resource map is made up of integers, subtract 2 for the resource type and length values
+                        int resourceCount = chunkLength / 4 - 2;
+                        resourceMap = new int[resourceCount];
+                        for (int i = 0; i < resourceCount; i++)
+                        {
+                            resourceMap[i] = input.ReadInt32();
+                        }
+
+                        break;
+                    case ResourceType.XmlStartNamespace:
+                        input.ReadInt32(); // Line number, currently unused
+                        if (input.ReadUInt32() != 0xFFFFFFFF)
+                        {
+                            throw new AxmlParseException("Expected 0xFFFFFFFF");
+                        }
+
+                        Debug.Assert(stringPool != null);
+                        int prefixId = input.ReadInt32();
+                        string? prefix = prefixId == -1 ? null : stringPool[prefixId];
+
+                        string uriString = stringPool[input.ReadInt32()];
+                        Uri uri = ParseNamespaceUri(uriString);
+                        
+                        queuedNamespaces.Add(new QueuedNamespace(prefix, uri));
+                        break;
+                    case ResourceType.XmlEndNamespace:
+                        break;
+                    case ResourceType.XmlStartElement:
+                        currentLineNumber = input.ReadInt32();
+                        if (input.ReadUInt32() != 0xFFFFFFFF)
+                        {
+                            throw new AxmlParseException("Expected 0xFFFFFFFF");
+                        }
+
+                        Debug.Assert(stringPool != null);
+                        int namespaceId = input.ReadInt32(); // -1 means no namespace prefix, so default namespace
+                        string elementName = stringPool[input.ReadInt32()];
+                        if (input.ReadUInt32() != 0x00140014)
+                        {
+                            throw new AxmlParseException("Expected 0x00140014");
+                        }
+                        
+                        AxmlElement childElement =
+                            new(currentLineNumber, elementName, namespaceId == -1
+                                ? null
+                                : ParseNamespaceUri(stringPool[namespaceId]));
+
+                        int numAttributes = input.ReadInt16();
+                        int idAttributeIndex = input.ReadInt16() - 1;
+                        int classAttributeIndex = input.ReadInt16() - 1;
+                        int styleAttributeIndex = input.ReadInt16() - 1;
+                        for (int i = 0; i < numAttributes; i++)
+                        {
+                            int attrNamespaceId = input.ReadInt32();
+                            Uri? attrNamespace = attrNamespaceId == -1 ? null : ParseNamespaceUri(stringPool[attrNamespaceId]);
+
+                            int attrNameAndResourceIdIndex = input.ReadInt32();
+
+                            string attrName = stringPool[attrNameAndResourceIdIndex];
+                            int? attrResourceId = null;
+                            
+                            if (resourceMap == null)
+                            {
+                                throw new AxmlParseException(
+                                    $"Attempted to access resource ID with index {attrNameAndResourceIdIndex} when the resource pool chunk had not yet been received");
+                            }
+                            if (attrNameAndResourceIdIndex >= 0 && attrNameAndResourceIdIndex < resourceMap.Length)
+                            {
+                                attrResourceId = resourceMap[attrNameAndResourceIdIndex];
+                            }
+
+                            int attrRawStringIndex = input.ReadInt32();
+                            AttributeType attrType = (AttributeType) (input.ReadInt32() >> 24); // The first byte contains the actual type, so we shift this to the right
+                            int attrRawValue = input.ReadInt32();
+
+                            object value;
+                            if (i == idAttributeIndex)
+                            {
+                                value = new WrappedValue(WrappedValueType.Id, stringPool[attrRawStringIndex],
+                                    attrRawValue);
+                            }
+                            else if(i == classAttributeIndex)
+                            {
+                                value = new WrappedValue(WrappedValueType.Class, stringPool[attrRawStringIndex],
+                                    attrRawValue);
+                            }   else if (i == styleAttributeIndex)
+                            {
+                                value = new WrappedValue(WrappedValueType.Style, stringPool[attrRawStringIndex],
+                                    attrRawValue);
+                            }
+                            else if(attrType == AttributeType.String)
+                            {
+                                value = stringPool[attrRawValue];
+                            }   else if (attrType == AttributeType.Boolean)
+                            {
+                                value = attrRawValue != 0;
+                            }
+                            else
+                            {
+                                value = attrRawValue;
+                            }
+
+                            childElement.Attributes.Add(new AxmlAttribute(attrName, attrNamespace, attrResourceId, value, attrType));
+                        }
+
+                        // Add the namespaces of any parent StartNamespace resources to this element
+                        foreach (QueuedNamespace ns in queuedNamespaces)
+                        {
+                            if (ns.Prefix == null) // No prefix means that this is a default namespace
+                            {
+                                childElement.DeclaredDefaultNamespace = ns.Uri;
+                            }
+                            else
+                            {
+                                childElement.DeclaredNamespaces[ns.Prefix] = ns.Uri;
+                            }
+                        }
+                        queuedNamespaces.Clear();
+
+                        // Add the child element to the current bottom-most element in the stack.
+                        if (elementStack.Count == 0)
+                        {
+                            if (rootElement != null)
+                            {
+                                throw new AxmlParseException("Document contained multiple root elements");
+                            }
+                            rootElement = childElement;
+                        }
+                        else
+                        {
+                            elementStack.Peek().Children.Add(childElement);
+                        }
+                        // Set this element as the bottom-most element
+                        elementStack.Push(childElement);
+                        
+                        
+                        break;
+                    case ResourceType.XmlEndElement:
+                        elementStack.Pop(); // Current bottom-most element is now the next element up
+                        break;
+                    case ResourceType.XmlCdata:
+                        input.ReadInt32(); // Line number, currently unused
+                        if (input.ReadUInt32() != 0xFFFFFFFF)
+                        {
+                            throw new AxmlParseException("Expected 0xFFFFFFFF");
+                        }
+
+                        input.ReadInt32(); // TODO: ID of "text" value. Currently unused
+                        
+                        // TODO: Unused bytes. (figure out what they are)
+                        input.ReadInt32();
+                        input.ReadInt32();
+
+                        break;
+                    default:
+                        throw new AxmlParseException("Unknown chunk type: " + chunkType);
+                }
+
+                input.BaseStream.Position = preChunkPosition + chunkLength;
+                preChunkPosition = (int) input.BaseStream.Position;
+            }
+
+            if (rootElement == null)
+            {
+                throw new AxmlParseException("Document did not contain a root element");
+            }
+
+            return rootElement;
+        }
+
+        /// <summary>
+        /// Parses a namespace URI, wrapping any parse failures in <see cref="AxmlParseException"/>
+        /// </summary>
+        /// <param name="uriString">The string of the URI to parse</param>
+        /// <returns>The URI that represents the given string</returns>
+        /// <exception cref="AxmlParseException">If any parsing errors occur. See inner exception for details</exception>
+        private static Uri ParseNamespaceUri(string uriString)
+        {
+            try
+            {
+                return new Uri(uriString);
+            }
+            catch (UriFormatException ex)
+            {
+                throw new AxmlParseException(
+                    $"Failed to parse URI {uriString} of namespace", ex);
+            }
+        }
+    }
+}

--- a/QuestPatcher.Axml/AxmlParseException.cs
+++ b/QuestPatcher.Axml/AxmlParseException.cs
@@ -1,0 +1,10 @@
+﻿using System;
+
+namespace QuestPatcher.Axml
+{
+    public class AxmlParseException : Exception
+    {
+        public AxmlParseException(string? message) : base(message) { }
+        public AxmlParseException(string? message, Exception? cause) : base(message, cause) { }
+    }
+}

--- a/QuestPatcher.Axml/AxmlSaver.cs
+++ b/QuestPatcher.Axml/AxmlSaver.cs
@@ -1,0 +1,48 @@
+﻿using System.IO;
+
+namespace QuestPatcher.Axml
+{
+    public static class AxmlSaver
+    {
+        public static void SaveDocument(Stream stream, AxmlElement rootElement)
+        {
+            BinaryWriter mainOutput = new(stream);
+
+            // Write the main elements chunk of the file to a MemoryStream first
+            SavingContext ctx = new();
+            rootElement.PrepareResourceIndices(ctx);
+            rootElement.Save(ctx);
+            MemoryStream mainChunkStream = (MemoryStream) ctx.Writer.BaseStream;
+
+
+            string[] stringPool = ctx.StringPool.Save();
+            int[] resourcePool = ctx.ResourcePool.Save();
+            
+            int stringPoolLength = StringPool.CalculatePoolLength(stringPool);
+            int stringPoolPadding = 4 - stringPoolLength % 4;
+            stringPoolLength += stringPoolPadding; // Add padding to four bytes
+            
+            int resourcePoolLength = resourcePool.Length * 4; // Each pool item is an integer
+
+            // The length of the main xml tag is that of the whole file, so also including the string pool, resource pool, and main chunk. (+ extra 8 + 8 = 16 bytes for string pool and resource pool header)
+            mainOutput.WriteChunkHeader(ResourceType.Xml, stringPoolLength + resourcePoolLength + (int) mainChunkStream.Position + 16);
+            
+            mainOutput.WriteChunkHeader(ResourceType.StringPool, stringPoolLength);
+            StringPool.SaveStringPool(stringPool, mainOutput);
+            for (int i = 0; i < stringPoolPadding; i++)
+            {
+                mainOutput.Write((byte) 0);
+            }
+            
+            mainOutput.WriteChunkHeader(ResourceType.XmlResourceMap, resourcePoolLength);
+            foreach (int resource in resourcePool)
+            {
+                mainOutput.Write(resource);
+            }
+            
+            // Save the main chunk of the file
+            mainChunkStream.Position = 0;
+            mainChunkStream.CopyTo(stream);
+        }
+    }
+}

--- a/QuestPatcher.Axml/BinaryStreamExtensions.cs
+++ b/QuestPatcher.Axml/BinaryStreamExtensions.cs
@@ -1,0 +1,38 @@
+﻿using System.IO;
+
+namespace QuestPatcher.Axml
+{
+    /// <summary>
+    /// Class for read/write methods convenient for AXML handling
+    /// </summary>
+    internal static class BinaryStreamExtensions
+    {
+        internal static ResourceType ReadResourceType(this BinaryReader reader)
+        {
+            int t = reader.ReadInt32();
+            return (ResourceType) (t & 0xFFFF);
+        }
+
+        internal static void WriteChunkHeader(this BinaryWriter writer, ResourceType typeEnum, int length = 0)
+        {
+            length += 8; // Length should include type and itself (two integers, so 8 extra bytes)
+
+            int typePrefix = typeEnum switch
+            {
+                ResourceType.Xml => 0x0008,
+                ResourceType.StringPool => 0x001C,
+                ResourceType.XmlResourceMap => 0x0008,
+                _ => 0x0010
+            };
+            writer.Write((int) typeEnum | typePrefix << 16);
+            writer.Write(length);
+        }
+
+        internal static void Write(this BinaryWriter writer, ResourceType resourceType)
+        {
+            writer.Write((int) resourceType);
+        }
+
+
+    }
+}

--- a/QuestPatcher.Axml/QuestPatcher.Axml.csproj
+++ b/QuestPatcher.Axml/QuestPatcher.Axml.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net5.0</TargetFramework>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
+    <DebugType>embedded</DebugType>
+  </PropertyGroup>
+  
+</Project>

--- a/QuestPatcher.Axml/README.md
+++ b/QuestPatcher.Axml/README.md
@@ -1,0 +1,12 @@
+﻿# QuestPatcher.Axml
+
+This project is used for the parsing and writing of the AXML format used for the `AndroidManifest.xml` file inside the APK.
+
+The AXML isn't completely parsed - styles are not currently supported.
+
+This implementation was based mostly off of this [Java Library](https://github.com/Sable/axml).
+
+### Why QuestPatcher doesn't use apktool
+QuestPatcher used to use apktool, however it proved quite unreliable, and a lot of its cached local data got continually corrupted.
+
+Fully decompiling the APK is also far more than QuestPatcher needs - we only need to add a couple of permissions to the manifest and change a few library files.

--- a/QuestPatcher.Axml/ResourceType.cs
+++ b/QuestPatcher.Axml/ResourceType.cs
@@ -1,0 +1,19 @@
+﻿namespace QuestPatcher.Axml
+{
+    internal enum ResourceType
+    {
+        StringPool = 0x0001,
+        Table = 0x0002,
+        PackageTable = 0x0200,
+        TypeSpecTable = 0x0202,
+        TypeTable = 0x0201,
+        
+        Xml = 0x0003,
+        XmlResourceMap = 0x0180,
+        XmlEndNamespace = 0x0101,
+        XmlEndElement = 0x0103,
+        XmlStartNamespace = 0x0100,
+        XmlStartElement = 0x0102,
+        XmlCdata = 0x0104
+    }
+}

--- a/QuestPatcher.Axml/SavingContext.cs
+++ b/QuestPatcher.Axml/SavingContext.cs
@@ -1,0 +1,58 @@
+﻿using System.Collections.Generic;
+using System.IO;
+
+namespace QuestPatcher.Axml
+{
+    internal class SavingContext
+    {
+        public class Pool<T> where T: notnull
+        {
+            private readonly Dictionary<T, int> _pool = new();
+            private int _nextIndex;
+
+            /// <summary>
+            /// Pools or returns the index in the pool of the specified value.
+            /// </summary>
+            /// <param name="value">The value to pool or return the index of</param>
+            /// <returns>The index (now) in the pool of the specified value</returns>
+            public int GetIndex(T value)
+            {
+                if (_pool.TryGetValue(value, out int index))
+                {
+                    return index;
+                }
+
+                _pool[value] = _nextIndex;
+                return _nextIndex++;
+            }
+            
+            /// <summary>
+            /// Saves this pool to an array.
+            /// The indices in the array correspond to the indices returned from <see cref="GetIndex"/>
+            /// </summary>
+            /// <returns>A one-dimensional array of the contents of this pool</returns>
+            public T[] Save()
+            {
+                T[] result = new T[_pool.Count];
+                foreach (KeyValuePair<T, int> pair in _pool)
+                {
+                    result[pair.Value] = pair.Key;
+                }
+
+                return result;
+            }
+        }
+
+        public Pool<string> StringPool { get; } = new();
+        public Pool<int> ResourcePool { get; } = new();
+
+        /// <summary>
+        /// The writer for the main section of the document, which is written to memory.
+        /// The main section is written to a <see cref="MemoryStream"/>> because the string/resource pool size determines the length at the beginning of the document.
+        /// Therefore it is impossible to know what we need to write in the pools without first writing the latter part of the document.
+        ///
+        /// This could be also done by an initial pass that adds all the strings to the pool, but this would add a lot of extra code, even though the memory usage would be more efficient.
+        /// </summary>
+        public BinaryWriter Writer { get; } = new(new MemoryStream());
+    }
+}

--- a/QuestPatcher.Axml/StringPool.cs
+++ b/QuestPatcher.Axml/StringPool.cs
@@ -1,0 +1,175 @@
+﻿using System.IO;
+using System.Text;
+
+namespace QuestPatcher.Axml
+{
+    internal static class StringPool
+    {
+        private const int Utf8Flag = 0x00000100;
+        
+        internal static string[] LoadStringPool(BinaryReader input)
+        {
+            int beginChunkOffset = (int) input.BaseStream.Position - 8;
+            int numStrings = input.ReadInt32();
+            input.ReadInt32(); // Style offset count, styles are currently unimplemented
+            
+            int flags = input.ReadInt32();
+            bool useUtf8 = (flags & Utf8Flag) != 0;
+            
+            int stringsOffset = input.ReadInt32();
+            input.ReadInt32(); // Style offset count, styles are currently unimplemented
+
+            int[] stringBeginOffsets = new int[numStrings];
+            for (int i = 0; i < numStrings; i++)
+            {
+                stringBeginOffsets[i] = input.ReadInt32();
+            }
+
+            string[] result = new string[numStrings];
+            
+            int stringsBeginning = beginChunkOffset + stringsOffset;
+            for(int i = 0; i < numStrings; i++)
+            {
+                input.BaseStream.Position = stringsBeginning + stringBeginOffsets[i];
+
+                string currentStr;
+                if (useUtf8)
+                {
+                    ReadUtf8Length(input); // Ignored, we just need to get past this varint
+                    int statedLength = ReadUtf8Length(input);
+
+                    MemoryStream stringStream = new();
+                    BinaryWriter stringWriter = new(stringStream);
+                    stringWriter.Write(input.ReadBytes(statedLength));
+                    while(true)
+                    {
+                        byte b = input.ReadByte();
+                        if (b == 0)
+                        {
+                            break;
+                        }
+                        
+                        stringWriter.Write(b);
+                    }
+
+                    currentStr =  Encoding.UTF8.GetString(stringStream.ToArray());
+                }
+                else
+                {
+                    int length = ReadUtf16Length(input);
+                    // Read string as UTF16_LE
+                    byte[] test = input.ReadBytes(length * 2);
+                    currentStr = Encoding.Unicode.GetString(test);
+                }
+
+                result[i] = currentStr;
+            }
+
+            return result;
+        }
+
+        /// <summary>
+        /// Calculates the length that the given string pool will take up when written (not inlcuding the resource type and length prefix)
+        /// </summary>
+        /// <param name="pool">The pool to calculate</param>
+        /// <returns>The length in bytes</returns>
+        internal static int CalculatePoolLength(string[] pool)
+        {
+            int stringsLength = 0;
+            foreach (string str in pool)
+            {
+                stringsLength += CalculatePooledStringLength(str);
+            }
+
+            return 20 + pool.Length * 4 + stringsLength;
+        }
+
+        /// <summary>
+        /// Saves the given strings as a string pool.
+        /// Assumes that the <see cref="ResourceType"/> and length prefix have already been sent
+        /// </summary>
+        /// <param name="pool"></param>
+        /// <param name="writer"></param>
+        internal static void SaveStringPool(string[] pool, BinaryWriter writer)
+        {
+            writer.Write(pool.Length);
+            writer.Write(0); // Style count, but we do not implement styles
+            writer.Write(0); // We do not use UTF-8 at the moment, UTF-16 is always used instead. If we were using UTF-8, this would be the Utf8Flag.
+            
+            // This value is the offset from the beginning of the chunk to the strings
+            // The initial 7 integers are resource type, chunk length, number of strings (pool length), style count (unused), UTF-8 flag (never set to non-zero), this value and 0 (the last I am unsure about).
+            // Then we have 1 integer per item in the pool, as the offset needs to be stored.
+            writer.Write(7 * 4 + pool.Length * 4);
+            writer.Write(0);
+            
+            int currentStringPos = 0;
+            foreach (string str in pool)
+            {
+                writer.Write(currentStringPos);
+                currentStringPos += CalculatePooledStringLength(str);
+            }
+            
+            foreach (string str in pool)
+            {
+                WriteUtf16Length(writer, str);
+                writer.Write(Encoding.Unicode.GetBytes(str));
+                writer.Write((byte) 0);
+                writer.Write((byte) 0);
+            }
+        }
+
+        /// <summary>
+        /// Reads the UTF-8 length format in axml, which is 1-2 bytes depending on size.
+        /// </summary>
+        /// <param name="input">Stream to read from</param>
+        /// <returns>Length of the proceeding UTF-8 string</returns>
+        private static int ReadUtf8Length(BinaryReader input)
+        {
+            int length = input.ReadByte();
+            if ((length & 0x80) != 0) // Next byte required
+            {
+                // Move the previous byte to the left, and add the second length byte to the end
+                length = ((length & 0x7F) << 8) | input.ReadByte();
+            }
+
+            return length;
+        }
+
+        /// <summary>
+        /// Reads the UTF-16 length format in axml, which is 2-4 bytes depending on size.
+        /// </summary>
+        /// <param name="input">Stream to read from</param>
+        /// <returns>Length of the proceeding UTF-16 string</returns>
+        private static int ReadUtf16Length(BinaryReader input)
+        {
+            int length = input.ReadInt16();
+            
+            if (length > 0x7FFF)  { // Second two bytes required
+                // Move the previous bytes to the left, and add the second two bytes to the end
+                length = ((length & 0x7FFF) << 8) | input.ReadUInt16(); 
+            }
+            return length;
+        }
+
+        /// <summary>
+        /// Writes the axml UTF-16 length of the given string. (2-4 bytes depending on size)
+        /// </summary>
+        /// <param name="output">Writer to write to</param>
+        /// <param name="str">String to write the length of</param>
+        private static void WriteUtf16Length(BinaryWriter output, string str)
+        {
+            if (str.Length > 0x7FFF) {
+                int x = (str.Length >> 16) | 0x8000;
+                output.Write((byte) x);
+                output.Write((byte) (x >> 8));
+            }
+            output.Write((byte) str.Length);
+            output.Write((byte) (str.Length >> 8));
+        }
+
+        private static int CalculatePooledStringLength(string str)
+        {
+            return (str.Length > 0x7FFF ? 4 : 2) + 2 + Encoding.Unicode.GetByteCount(str);
+        }
+    }
+}

--- a/QuestPatcher.Axml/WrappedValue.cs
+++ b/QuestPatcher.Axml/WrappedValue.cs
@@ -1,0 +1,39 @@
+﻿namespace QuestPatcher.Axml
+{
+    public enum WrappedValueType
+    {
+        Id,
+        Style,
+        Class,
+        Reference
+    }
+    
+    /// <summary>
+    /// Represents an AXML ID, Style or Class attribute value.
+    /// These values have a reference ID and an underlying string value
+    /// </summary>
+    public class WrappedValue
+    {
+        /// <summary>
+        /// Type of the underlying string value
+        /// </summary>
+        public WrappedValueType Type { get; }
+        
+        /// <summary>
+        /// Raw underlying string value that represents this value.
+        /// </summary>
+        public string RawValue { get; }
+        
+        /// <summary>
+        /// TODO: figure out what this is
+        /// </summary>
+        public int ReferenceId { get; }
+
+        public WrappedValue(WrappedValueType type, string rawValue, int referenceId)
+        {
+            Type = type;
+            RawValue = rawValue;
+            ReferenceId = referenceId;
+        }
+    }
+}

--- a/QuestPatcher.Core/ApkTools.cs
+++ b/QuestPatcher.Core/ApkTools.cs
@@ -6,7 +6,8 @@ using System.Threading.Tasks;
 namespace QuestPatcher.Core
 {
     /// <summary>
-    /// Abstraction around APKtool and uber-apk-signer used during patching.
+    /// Abstraction around uber-apk-signer used during patching.
+    /// Used to abstract apktool as well, but QuestPatcher no longer uses this, relying on its own manifest decompiler instead.
     /// </summary>
     public class ApkTools
     {
@@ -68,16 +69,6 @@ namespace QuestPatcher.Core
                 // Download Java if it is not installed
                 _javaExecutableName = await _filesDownloader.GetFileLocation(ExternalFileType.Jre);
             }
-        }
-
-        public Task DecompileApk(string apkPath, string extractPath)
-        {
-            return InvokeJavaTool(ExternalFileType.ApkTool, $"d -f -o \"{extractPath}\" \"{apkPath}\"");
-        }
-
-        public Task CompileApk(string extractPath, string resultPath)
-        {
-            return InvokeJavaTool(ExternalFileType.ApkTool, $"b -f -o \"{resultPath}\" \"{extractPath}\"");
         }
 
         public Task SignApk(string apkPath)

--- a/QuestPatcher.Core/ExternalFilesDownloader.cs
+++ b/QuestPatcher.Core/ExternalFilesDownloader.cs
@@ -20,7 +20,6 @@ namespace QuestPatcher.Core
         Main32,
         Main64,
         UberApkSigner,
-        ApkTool,
         PlatformTools,
         Jre,
     }
@@ -61,14 +60,6 @@ namespace QuestPatcher.Core
 
         private readonly Dictionary<ExternalFileType, FileInfo> _fileTypes = new()
         {
-            {
-                ExternalFileType.ApkTool,
-                new FileInfo
-                {
-                    SaveName = "apktool.jar".ForAllSystems(),
-                    DownloadUrl = "https://bitbucket.org/iBotPeaches/apktool/downloads/apktool_2.5.0.jar".ForAllSystems()
-                }
-            },
             {
                 ExternalFileType.UberApkSigner,
                 new FileInfo

--- a/QuestPatcher.Core/ExternalFilesDownloader.cs
+++ b/QuestPatcher.Core/ExternalFilesDownloader.cs
@@ -19,6 +19,7 @@ namespace QuestPatcher.Core
         Modloader64,
         Main32,
         Main64,
+        ApkTool,
         UberApkSigner,
         PlatformTools,
         Jre,

--- a/QuestPatcher.Core/Patching/PatchingManager.cs
+++ b/QuestPatcher.Core/Patching/PatchingManager.cs
@@ -7,9 +7,11 @@ using System.ComponentModel;
 using System.Diagnostics;
 using System.IO;
 using System.IO.Compression;
+using System.Linq;
 using System.Net;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
+using QuestPatcher.Axml;
 
 namespace QuestPatcher.Core.Patching
 {
@@ -18,6 +20,13 @@ namespace QuestPatcher.Core.Patching
     /// </summary>
     public class PatchingManager : INotifyPropertyChanged
     {
+        private const string ManifestPath = "AndroidManifest.xml";
+        private static readonly Uri AndroidNamespaceUri = new("http://schemas.android.com/apk/res/android");
+        private const int NameAttributeResourceId = 16842755;
+        private const int RequiredAttributeResourceId = 16843406;
+        private const int DebuggableAttributeResourceId = 16842767;
+        private const int LegacyStorageAttributeResourceId = 16844291;
+
         public ApkInfo? InstalledApp { get => _installedApp; private set { if (_installedApp != value) { _installedApp = value; NotifyPropertyChanged(); } } }
         private ApkInfo? _installedApp;
 
@@ -37,8 +46,7 @@ namespace QuestPatcher.Core.Patching
         private readonly IUserPrompter _prompter;
         private readonly Action _quit;
 
-        private readonly string _currentApkPath;
-        private readonly string _decompPath;
+        private readonly string _storedApkPath;
         private Dictionary<string, Dictionary<string, string>>? _libUnityIndex;
 
         public PatchingManager(Logger logger, Config config, AndroidDebugBridge debugBridge, ApkTools apkTools, SpecialFolders specialFolders, ExternalFilesDownloader filesDownloader, IUserPrompter prompter, Action quit)
@@ -52,8 +60,7 @@ namespace QuestPatcher.Core.Patching
             _prompter = prompter;
             _quit = quit;
 
-            _currentApkPath = Path.Combine(specialFolders.PatchingFolder, "currentlyInstalled.apk");
-            _decompPath = Path.Combine(specialFolders.PatchingFolder, "decompiledApp");
+            _storedApkPath = Path.Combine(specialFolders.PatchingFolder, "currentlyInstalled.apk");
         }
 
         private void NotifyPropertyChanged([CallerMemberName] string propertyName = "")
@@ -67,7 +74,7 @@ namespace QuestPatcher.Core.Patching
             _logger.Information($"App Version: {version}");
 
             _logger.Information("Downloading APK from the Quest . . .");
-            await _debugBridge.DownloadApk(_config.AppId, _currentApkPath);
+            await _debugBridge.DownloadApk(_config.AppId, _storedApkPath);
 
             bool isModded = false;
             bool is64Bit = false;
@@ -76,7 +83,7 @@ namespace QuestPatcher.Core.Patching
             _logger.Information("Checking APK modding status . . .");
             await Task.Run(() =>
             {
-                using ZipArchive apkArchive = ZipFile.OpenRead(_currentApkPath);
+                using ZipArchive apkArchive = ZipFile.OpenRead(_storedApkPath);
 
                 // QuestPatcher adds a tag file to determine if the APK is modded later on
                 isModded = apkArchive.GetEntry("modded") != null || apkArchive.GetEntry("BMBF.modded") != null;
@@ -99,7 +106,7 @@ namespace QuestPatcher.Core.Patching
             InstalledApp = null;
         }
 
-        private async Task<bool> AttemptCopyUnstrippedUnity(string libsPath)
+        private async Task<bool> AttemptCopyUnstrippedUnity(string libsPath, ZipArchive apkArchive)
         {
             WebClient client = new();
             // Only download the index once
@@ -137,149 +144,217 @@ namespace QuestPatcher.Core.Patching
             }
 
             _logger.Information("Unstripped libunity found. Downloading . . .");
-            await _filesDownloader.DownloadUrl($"https://raw.githubusercontent.com/Lauriethefish/QuestUnstrippedUnity/main/versions/{correctVersion}.so", Path.Combine(libsPath, "libunity.so"));
+            string tempDownloadPath = _specialFolders.GetTempFilePath();
+            try
+            {
+                await _filesDownloader.DownloadUrl(
+                    $"https://raw.githubusercontent.com/Lauriethefish/QuestUnstrippedUnity/main/versions/{correctVersion}.so",
+                    tempDownloadPath, "libunity.so");
+
+                apkArchive.CopyFileToArchive(tempDownloadPath, Path.Combine(libsPath, "libunity.so"), true);
+            }
+            finally
+            {
+                if (File.Exists(tempDownloadPath)) { File.Delete(tempDownloadPath); }
+            }
+
             return true;
         }
 
-        /// <summary>
-        /// Adds permissions for modding, as specified in the config.
-        /// This does not parse the XML, simply uses string manipulation because it was easier and it's a strange form of XML that nothing will read.
-        /// </summary>
-        /// <param name="manifest">The manifest to add the permissions to</param>
-        /// <returns>The modified manifest</returns>
-        private string PatchManifest(string manifest)
+        public void PatchManifest(ZipArchive apkArchive)
         {
-
-            // This is future-proofing as in Android 11 WRITE and READ is replaced by MANAGE.
-            // Otherwise storage access would be limited to scoped-storage like an app-specific directory or a public shared directory.
-            // Can be removed until any device updates to Android 11, however it's best to keep for compatability.
-
-            const string readPermissions = "<uses-permission android:name=\"android.permission.READ_EXTERNAL_STORAGE\"/>";
-            const string writePermissions = "<uses-permission android:name=\"android.permission.WRITE_EXTERNAL_STORAGE\"/>";
-            const string managePermissions = "<uses-permission android:name=\"android.permission.MANAGE_EXTERNAL_STORAGE\"/>";
-
-            // Required for Apps that target Android 10 API Level 29 or higher as that uses scoped storage see: https://developer.android.com/training/data-storage/use-cases#opt-out-scoped-storage
-            const string legacyExternalStorage = "android:requestLegacyExternalStorage = \"true\"";
-            const string applicationDebuggable = "android:debuggable = \"true\"";
-
-            // Hand tracking features and permissions
-            const string ovrFeatureHandTracking = "<uses-feature android:name=\"oculus.software.handtracking\" android:required=\"false\"/>";
-            const string ovrPermissionHandTracking = "<uses-permission android:name=\"oculus.permission.handtracking\"/>\n<uses-permission android:name=\"com.oculus.permission.HAND_TRACKING\"/>";
-
-            const string applicationStr = "<application";
-
-            int newLineIndex = manifest.IndexOf('\n');
-            string newManifest = manifest.Substring(0, newLineIndex) + "\n";
-
-            if (_config.PatchingPermissions.ExternalFiles)
+            ZipArchiveEntry? manifestEntry = apkArchive.GetEntry(ManifestPath);
+            if (manifestEntry == null)
             {
-                _logger.Information("Adding storage permissions . . .");
-                if (!manifest.Contains(readPermissions))
-                {
-                    newManifest += "    " + readPermissions + "\n";
-                }
-
-                if (!manifest.Contains(writePermissions))
-                {
-                    newManifest += "    " + writePermissions + "\n";
-                }
-
-                if (!manifest.Contains(managePermissions))
-                {
-                    newManifest += "    " + managePermissions + "\n";
-                }
-
-                if (!manifest.Contains(legacyExternalStorage))
-                {
-                    _logger.Debug("Adding legacy storage support . . .");
-                    manifest = manifest.Replace(applicationStr, $"{applicationStr} {legacyExternalStorage}");
-                }
-            }
-            else
-            {
-                _logger.Warning("No external file permissions granted - many mods will not work!");
+                throw new PatchingException($"APK missing {ManifestPath} to patch");
             }
 
-            if (_config.PatchingPermissions.Debuggable)
+            // The AMXL loader requires a seekable stream
+            MemoryStream ms = new();
+            using (Stream stream = manifestEntry.Open())
             {
-                if (!manifest.Contains(applicationDebuggable))
-                {
-                    _logger.Information("Adding debuggable flag . . .");
-                    manifest = manifest.Replace(applicationStr, $"{applicationStr} {applicationDebuggable}");
-                }
+                stream.CopyTo(ms);
             }
 
-            if(_config.PatchingPermissions.HandTracking)
-            {
-                _logger.Information("Adding hand tracking . . .");
-                if (!manifest.Contains(ovrFeatureHandTracking))
-                {
-                    newManifest += "    " + ovrFeatureHandTracking + "\n";
-                }
+            ms.Position = 0;
+            _logger.Information("Loading manifest as AXML . . .");
+            AxmlElement manifest = AxmlLoader.LoadDocument(ms);
 
-                if (!manifest.Contains(ovrPermissionHandTracking))
-                {
-                    newManifest += "    " + ovrPermissionHandTracking + "\n";
-                }
+            // First we add permissions and features to the APK for modding
+            List<string> addingPermissions = new();
+            List<string> addingFeatures = new();
+            PatchingPermissions permissions = _config.PatchingPermissions;
+            if (permissions.ExternalFiles)
+            {
+                // Technically, we only need READ_EXTERNAL_STORAGE and WRITE_EXTERNAL_STORAGE, but we also add MANAGE_EXTERNAL_STORAGE as this is what Android 11 needs instead
+                addingPermissions.AddRange(new[] {
+                    "android.permission.READ_EXTERNAL_STORAGE", 
+                    "android.permission.WRITE_EXTERNAL_STORAGE",
+                    "android.permission.MANAGE_EXTERNAL_STORAGE"
+                });
             }
 
-            newManifest += manifest[(newLineIndex + 1)..]; // Add the rest of the original manifest
-            return newManifest;
+            if (permissions.HandTracking)
+            {
+                // For some reason these are separate permissions, but we need both of them
+                addingPermissions.AddRange(new[]
+                {
+                    "oculus.permission.handtracking",
+                    "com.oculus.permission.HAND_TRACKING"
+                });
+                // Tell Android (and thus Oculus home) that this app supports hand tracking and we can launch the app with it
+                addingFeatures.Add("oculus.software.handtracking");
+            }
+
+            // Find which features and permissions already exist to avoid adding existing ones
+            ISet<string> existingPermissions = GetExistingChildren(manifest, "uses-permission");
+            ISet<string> existingFeatures = GetExistingChildren(manifest, "uses-feature");
+
+            foreach (string permission in addingPermissions)
+            {
+                if(existingPermissions.Contains(permission)) { continue; } // Do not add existing permissions
+
+                _logger.Information($"Adding permission {permission}");
+                AxmlElement permElement = new(0, "uses-permission", null);
+                AddNameAttribute(permElement, permission);
+                manifest.Children.Add(permElement);
+            }
+
+            foreach (string feature in addingFeatures)
+            {
+                if(existingFeatures.Contains(feature)) { continue; } // Do not add existing features
+
+                _logger.Information($"Adding feature {feature}");
+                AxmlElement featureElement = new(0, "uses-feature", null);
+                AddNameAttribute(featureElement, feature);
+                
+                // TODO: User may want the feature to be required instead of suggested
+                featureElement.Attributes.Add(new AxmlAttribute("required", AndroidNamespaceUri, RequiredAttributeResourceId, false));
+                manifest.Children.Add(featureElement);
+            }
+
+            // Now we need to add the legacyStorageSupport and debuggable flags
+            AxmlElement appElement = manifest.Children.Single(element => element.Name == "application");
+            if (permissions.Debuggable && !appElement.Attributes.Any(attribute => attribute.Name == "debuggable"))
+            {
+                _logger.Information("Adding debuggable flag . . .");
+                appElement.Attributes.Add(new AxmlAttribute("debuggable", AndroidNamespaceUri, DebuggableAttributeResourceId, true));
+            }
+
+            if (permissions.ExternalFiles && !appElement.Attributes.Any(attribute => attribute.Name == "requestLegacyExternalStorage"))
+            {
+                _logger.Information("Adding legacy external storage flag . . .");
+                appElement.Attributes.Add(new AxmlAttribute("requestLegacyExternalStorage", AndroidNamespaceUri, LegacyStorageAttributeResourceId, true));
+            }
+            
+            // Save the manifest using our AXML library
+            // TODO: The AXML library is missing some features such as styles.
+            _logger.Information("Saving manifest as AXML . . .");
+            manifestEntry.Delete(); // Remove old manifest
+            manifestEntry = apkArchive.CreateEntry(ManifestPath);
+            using Stream saveStream = manifestEntry.Open();
+            AxmlSaver.SaveDocument(saveStream, manifest);
         }
 
+        /// <summary>
+        /// Scans the attributes of the children of the given element for their "name" attribute.
+        /// </summary>
+        /// <param name="manifest"></param>
+        /// <param name="childNames"></param>
+        /// <returns>A set of the values of the "name" attributes of children (does not error on children without this attribute)</returns>
+        private ISet<string> GetExistingChildren(AxmlElement manifest, string childNames)
+        {
+            HashSet<string> result = new();
+            
+            foreach (AxmlElement element in manifest.Children)
+            {
+                if(element.Name != childNames) { continue; }
+
+                List<AxmlAttribute> nameAttributes = element.Attributes.Where(attribute => attribute.Namespace == AndroidNamespaceUri && attribute.Name == "name").ToList();
+                // Only add children with the name attribute
+                if (nameAttributes.Count > 0) { result.Add((string) nameAttributes[0].Value); }
+            }
+
+            return result;
+        }
+
+        /// <summary>
+        /// Adds a "name" attribute to the given element, with the given value.
+        /// </summary>
+        /// <param name="element">The element to add the attribute to</param>
+        /// <param name="name">The value to put in the name attribute</param>
+        private void AddNameAttribute(AxmlElement element, string name)
+        {
+            element.Attributes.Add(new AxmlAttribute("name", AndroidNamespaceUri, NameAttributeResourceId, name));
+        }
+
+        /// <summary>
+        /// Begins patching the currently installed APK. (must be pulled before calling this)
+        /// </summary>
         public async Task PatchApp()
         {
-            _logger.Information("Decompiling APK . . .");
-            PatchingStage = PatchingStage.Decompiling;
-
-            Directory.CreateDirectory(_decompPath);
-            await _apkTools.DecompileApk(_currentApkPath, _decompPath);
-            _logger.Information("Decompiled APK");
-
-            _logger.Information("Copying library files to patch APK . . .");
-            PatchingStage = PatchingStage.Patching;
             if (InstalledApp == null)
             {
                 throw new NullReferenceException("Cannot patch before installed app has been checked");
             }
-            string libsPath = Path.Combine(_decompPath, InstalledApp.Is64Bit ? "lib/arm64-v8a" : "lib/armeabi-v7a");
+            _logger.Information("Copying APK to patched location . . .");
 
-            if (!InstalledApp.Is64Bit)
+            string patchedApkPath = Path.Combine(_specialFolders.PatchingFolder, "patched.apk");
+            File.Copy(_storedApkPath, patchedApkPath);
+            
+            _logger.Information("Copying files to patch APK . . .");
+
+            using (ZipArchive apkArchive = ZipFile.Open(patchedApkPath, ZipArchiveMode.Update))
             {
-                _logger.Warning("App is 32 bit!");
-                if (!await _prompter.Prompt32Bit()) // Prompt the user to ask if they would like to continue, even though BS-hook doesn't work on 32 bit apps
+
+                PatchingStage = PatchingStage.Patching;
+                string libsPath = InstalledApp.Is64Bit ? "lib/arm64-v8a" : "lib/armeabi-v7a";
+
+                if (!InstalledApp.Is64Bit)
                 {
-                    return;
+                    _logger.Warning("App is 32 bit!");
+                    if (
+                        !await _prompter
+                            .Prompt32Bit()) // Prompt the user to ask if they would like to continue, even though BS-hook doesn't work on 32 bit apps
+                    {
+                        return;
+                    }
                 }
-            }
 
-            if (!await AttemptCopyUnstrippedUnity(libsPath))
-            {
-                if (!await _prompter.PromptUnstrippedUnityUnavailable()) // Prompt the user to ask if they would like to continue, since missing libunity is likely to break some mods
+                if (!await AttemptCopyUnstrippedUnity(libsPath, apkArchive))
                 {
-                    return;
+                    if (!await _prompter
+                        .PromptUnstrippedUnityUnavailable()) // Prompt the user to ask if they would like to continue, since missing libunity is likely to break some mods
+                    {
+                        return;
+                    }
                 }
-            }
 
-            // Replace libmain.so to load the modloader, then add libmodloader.so, which actually does the mod loading.
-            _logger.Information("Copying libmain.so and libmodloader.so . . .");
-            if (InstalledApp.Is64Bit)
-            {
-                File.Copy(await _filesDownloader.GetFileLocation(ExternalFileType.Main64), Path.Combine(libsPath, "libmain.so"), true);
-                File.Copy(await _filesDownloader.GetFileLocation(ExternalFileType.Modloader64), Path.Combine(libsPath, "libmodloader.so"));
-            }
-            else
-            {
-                _logger.Warning("Using 32 bit versions!");
-                File.Copy(await _filesDownloader.GetFileLocation(ExternalFileType.Main32), Path.Combine(libsPath, "libmain.so"), true);
-                File.Copy(await _filesDownloader.GetFileLocation(ExternalFileType.Modloader32), Path.Combine(libsPath, "libmodloader.so"));
-            }
+                // Replace libmain.so to load the modloader, then add libmodloader.so, which actually does the mod loading.
+                _logger.Information("Copying libmain.so and libmodloader.so . . .");
+                if (InstalledApp.Is64Bit)
+                {
+                    apkArchive.CopyFileToArchive(await _filesDownloader.GetFileLocation(ExternalFileType.Main64), Path.Combine(libsPath, "libmain.so"), true);
+                    apkArchive.CopyFileToArchive(await _filesDownloader.GetFileLocation(ExternalFileType.Modloader64), Path.Combine(libsPath, "libmodloader.so"));
+                }
+                else
+                {
+                    _logger.Warning("Using 32 bit versions!");
+                    apkArchive.CopyFileToArchive(await _filesDownloader.GetFileLocation(ExternalFileType.Main32), Path.Combine(libsPath, "libmain.so"), true);
+                    apkArchive.CopyFileToArchive(await _filesDownloader.GetFileLocation(ExternalFileType.Modloader32), Path.Combine(libsPath, "libmodloader.so"));
+                }
 
-            // Add permissions to the manifest
-            _logger.Information("Patching manifest . . .");
-            string manifestPath = Path.Combine(_decompPath, "AndroidManifest.xml");
-            string modifiedManifest = PatchManifest(await File.ReadAllTextAsync(manifestPath));
-            await File.WriteAllTextAsync(manifestPath, modifiedManifest);
+                // Add permissions to the manifest
+                _logger.Information("Patching manifest . . .");
+                PatchManifest(apkArchive);
+                
+                _logger.Information("Adding tag . . .");
+                // The disk IO while opening the APK as a zip archive causes a UI freeze, so we run it on another thread
+                // We cannot just create this tag before compiling - apktool will remove it as it isn't a normal part of the APK
+                apkArchive.CreateEntry("modded");
+                
+                _logger.Information("Closing APK archive . . .");
+            }
 
             // Pause patching before compiling the APK in order to give a developer the chance to modify it.
             if(_config.PauseBeforeCompile && !await _prompter.PromptPauseBeforeCompile())
@@ -287,40 +362,13 @@ namespace QuestPatcher.Core.Patching
                 return;
             }
 
-            _logger.Information("Recompiling APK . . .");
-            PatchingStage = PatchingStage.Recompiling;
-
-            string patchedPath = Path.Combine(_specialFolders.PatchingFolder, "patched.apk");
-            await _apkTools.CompileApk(_decompPath, patchedPath);
-
-            try
-            {
-                await Task.Run(() =>
-                {
-                    Directory.Delete(_decompPath, true); // The decompiled APK takes up a LOT of space (800-900 MB for Beat Saber!), so we clear this now
-                });
-            } 
-            catch (IOException) // Sometimes a developer might be using the APK, so avoid failing the whole patching process
-            {
-                _logger.Warning("Failed to delete decompiled APK");
-            }
-
-            _logger.Information("Adding tag . . .");
-            // The disk IO while opening the APK as a zip archive causes a UI freeze, so we run it on another thread
-            // We cannot just create this tag before compiling - apktool will remove it as it isn't a normal part of the APK
-            await Task.Run(() =>
-            {
-                using ZipArchive apkArchive = ZipFile.Open(patchedPath, ZipArchiveMode.Update);
-                apkArchive.CreateEntry("modded");
-            });
-
             _logger.Information("Signing APK (this might take a while) . . .");
             PatchingStage = PatchingStage.Signing;
 
-            await _apkTools.SignApk(patchedPath);
+            await _apkTools.SignApk(patchedApkPath);
             try
             {
-                File.Delete(patchedPath); // The patched APK takes up space, and we don't need it now
+                File.Delete(patchedApkPath); // The patched APK takes up space, and we don't need it now
             }
             catch (IOException) // Sometimes a developer might be using the APK, so avoid failing the whole patching process
             {

--- a/QuestPatcher.Core/Patching/PatchingManager.cs
+++ b/QuestPatcher.Core/Patching/PatchingManager.cs
@@ -314,7 +314,7 @@ namespace QuestPatcher.Core.Patching
             string patchedApkPath = Path.Combine(_specialFolders.PatchingFolder, "patched.apk");
 
             // There is no async file copy method, so we Task.Run it (we could make our own with streams, that's another option)
-            await Task.Run(() => { File.Copy(_storedApkPath, patchedApkPath); });
+            await Task.Run(() => { File.Copy(_storedApkPath, patchedApkPath, true); });
             
             _logger.Information("Copying files to patch APK . . .");
 

--- a/QuestPatcher.Core/Patching/PatchingStage.cs
+++ b/QuestPatcher.Core/Patching/PatchingStage.cs
@@ -6,9 +6,8 @@
     public enum PatchingStage
     {
         NotStarted,
-        Decompiling,
+        MovingToTemp,
         Patching,
-        Recompiling,
         Signing,
         UninstallingOriginal,
         InstallingModded

--- a/QuestPatcher.Core/Patching/ZipExtensions.cs
+++ b/QuestPatcher.Core/Patching/ZipExtensions.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.IO.Compression;
+
+namespace QuestPatcher.Core.Patching
+{
+    public static class ZipExtensions
+    {
+        /// <summary>
+        /// Copies a file to the archive, overwriting if <code>overwrite</code> is set to <code>true</code>.
+        /// </summary>
+        /// <param name="archive">Archive to copy the file to</param>
+        /// <param name="sourcePath">Where to copy the file from</param>
+        /// <param name="entryName">Where to copy the file in the archive</param>
+        /// <param name="overwrite">Used if an entry already exists with the given <paramRef name="entryName"/>. If set to <code>true</code>, the existing entry will be removed and a new entry will be created. Otherwise, <see cref="InvalidOperationException"/> is thrown.</param>
+        /// <param name="enforceForwardSlash">If true, any backward slashes in the <paramRef name="entryName"/> will be replaced with forward slashes.</param>
+        /// <exception cref="InvalidOperationException">If an entry with name <paramRef name="entryName"/> already exists and <paramRef name="overwrite"/> is set to <code>false</code></exception>
+        public static void CopyFileToArchive(this ZipArchive archive, string sourcePath, string entryName, bool overwrite = false, bool enforceForwardSlash = true)
+        {
+            if (enforceForwardSlash)
+            {
+                entryName = entryName.Replace("\\", "/");
+            }
+            
+            ZipArchiveEntry? existingEntry = archive.GetEntry(entryName.Replace("\\", "/"));
+            if (existingEntry != null)
+            {
+                if (overwrite)
+                {
+                    existingEntry.Delete();
+                }
+                else
+                {
+                    throw new InvalidOperationException(
+                        $"Failed to copy file to archive: Entry {entryName} existed, and overwrite was set to false");
+                }
+            }
+
+            archive.CreateEntryFromFile(sourcePath, entryName);
+        }
+    }
+}

--- a/QuestPatcher.Core/QuestPatcher.Core.csproj
+++ b/QuestPatcher.Core/QuestPatcher.Core.csproj
@@ -21,7 +21,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <EmbeddedResource Include="Resources\**" />
+    <ProjectReference Include="..\QuestPatcher.Axml\QuestPatcher.Axml.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <EmbeddedResource Include="Resources\**" />
+  </ItemGroup>
+  
 </Project>

--- a/QuestPatcher.Core/QuestPatcherService.cs
+++ b/QuestPatcher.Core/QuestPatcherService.cs
@@ -177,30 +177,12 @@ namespace QuestPatcher.Core
         }
 
         /// <summary>
-        /// Clears cached QuestPatcher files, and deletes APKtool temporary files.
+        /// Clears cached QuestPatcher files.
         /// This really shouldn't be necessary, but often fixes issues.
-        /// The "partially extracted download" or "partially downloaded file" causing issues shouldn't be a thing with the new file download system, however this is here just in case it still is.
+        /// The "partially extracted download" or "partially downloaded file" causing issues shouldn't be an issue with the new file download system, however this is here just in case it still is.
         /// </summary>
         public async Task QuickFix()
         {
-            // Apktool temporary files sometimes get corrupted, so we delete them
-            string apkToolFilesPath;
-            if (OperatingSystem.IsMacOS())
-            {
-                apkToolFilesPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile, Environment.SpecialFolderOption.DoNotVerify), "Library/apktool");
-            }
-            else
-            {
-                apkToolFilesPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData, Environment.SpecialFolderOption.DoNotVerify), "apktool");
-            }
-            
-            Logger.Information("Deleting apktool temp files . . .");
-            Logger.Debug($"Temp files path: {apkToolFilesPath}");
-            if (Directory.Exists(apkToolFilesPath))
-            {
-                Directory.Delete(apkToolFilesPath, true);
-            }
-
             await DebugBridge.KillServer(); // Allow ADB to be deleted
 
             // Sometimes files fail to download so we clear them. This shouldn't happen anymore but I may as well add it to be on the safe side

--- a/QuestPatcher.sln
+++ b/QuestPatcher.sln
@@ -7,6 +7,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "QuestPatcher", "QuestPatche
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "QuestPatcher.Core", "QuestPatcher.Core\QuestPatcher.Core.csproj", "{C02D15DD-D4A2-478A-9129-500EF33BF05D}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "QuestPatcher.Axml", "QuestPatcher.Axml\QuestPatcher.Axml.csproj", "{9F254220-2B69-4CD0-86FC-E5F3C2E3BDFF}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -21,6 +23,10 @@ Global
 		{C02D15DD-D4A2-478A-9129-500EF33BF05D}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{C02D15DD-D4A2-478A-9129-500EF33BF05D}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{C02D15DD-D4A2-478A-9129-500EF33BF05D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9F254220-2B69-4CD0-86FC-E5F3C2E3BDFF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9F254220-2B69-4CD0-86FC-E5F3C2E3BDFF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9F254220-2B69-4CD0-86FC-E5F3C2E3BDFF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9F254220-2B69-4CD0-86FC-E5F3C2E3BDFF}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/QuestPatcher/ViewModels/PatchingViewModel.cs
+++ b/QuestPatcher/ViewModels/PatchingViewModel.cs
@@ -101,12 +101,10 @@ namespace QuestPatcher.ViewModels
             PatchingStageText = stage switch
             {
                 PatchingStage.NotStarted => "Not Started",
-                PatchingStage.Decompiling => "Decompiling APK (patching stage 1/6)",
-                PatchingStage.Patching => "Modifying APK files to support mods (patching stage 2/6)",
-                PatchingStage.Recompiling => "Compiling modded APK (patching stage 3/6)",
-                PatchingStage.Signing => "Signing APK (patching stage 4/6)",
-                PatchingStage.UninstallingOriginal => "Uninstalling original APK to install modded APK (patching stage 5/6)",
-                PatchingStage.InstallingModded => "Installing modded APK (patching stage 6/6)",
+                PatchingStage.Patching => "Modifying APK files to support mods (patching stage 1/4)",
+                PatchingStage.Signing => "Signing APK (patching stage 2/4)",
+                PatchingStage.UninstallingOriginal => "Uninstalling original APK to install modded APK (patching stage 3/4)",
+                PatchingStage.InstallingModded => "Installing modded APK (patching stage 4/4)",
                 _ => throw new NotImplementedException()
             };
             this.RaisePropertyChanged(nameof(PatchingStageText));

--- a/QuestPatcher/ViewModels/PatchingViewModel.cs
+++ b/QuestPatcher/ViewModels/PatchingViewModel.cs
@@ -101,10 +101,11 @@ namespace QuestPatcher.ViewModels
             PatchingStageText = stage switch
             {
                 PatchingStage.NotStarted => "Not Started",
-                PatchingStage.Patching => "Modifying APK files to support mods (patching stage 1/4)",
-                PatchingStage.Signing => "Signing APK (patching stage 2/4)",
-                PatchingStage.UninstallingOriginal => "Uninstalling original APK to install modded APK (patching stage 3/4)",
-                PatchingStage.InstallingModded => "Installing modded APK (patching stage 4/4)",
+                PatchingStage.MovingToTemp => "Moving APK to temporary location (patching stage 1/5)",
+                PatchingStage.Patching => "Modifying APK files to support mods (patching stage 2/5)",
+                PatchingStage.Signing => "Signing APK (patching stage 3/5)",
+                PatchingStage.UninstallingOriginal => "Uninstalling original APK to install modded APK (patching stage 4/5)",
+                PatchingStage.InstallingModded => "Installing modded APK (patching stage 5/5)",
                 _ => throw new NotImplementedException()
             };
             this.RaisePropertyChanged(nameof(PatchingStageText));

--- a/QuestPatcher/Views/ToolsView.axaml
+++ b/QuestPatcher/Views/ToolsView.axaml
@@ -32,7 +32,7 @@
         </StackPanel>
         <StackPanel Orientation="Horizontal" Spacing="10">
           <Button Command="{Binding QuickFix}" IsEnabled="{Binding Locker.IsFree}">Quick Fix</Button>
-          <TextBlock VerticalAlignment="Center" FontSize="12">Clears cached QuestPatcher &amp; apktool data - try this if something isn't working.</TextBlock>
+          <TextBlock VerticalAlignment="Center" FontSize="12">Clears cached QuestPatcher data - try this if something isn't working.</TextBlock>
         </StackPanel>
       </StackPanel>
       <StackPanel  Margin="0 20 0 0" Spacing="10">


### PR DESCRIPTION
This PR changes QuestPatcher to use its own custom implementation for decoding the `AndroidManifest.xml` file, instead of relying on apktool.

Apktool is far more than we really need - we don't need to decompile the whole APK - just change some values in the manifest and add a couple of library files. It has also proved to be quite unreliable, and the cached data got corrupted quite often.

The AXML implementation (the manifest loader/saver) is based off of this [Java Implementation](https://github.com/Sable/axml).


Not decompiling the whole APK makes patching significantly faster too!
