### PR TITLE
Add support for quicker loading using a modded permission.

### DIFF
--- a/QuestPatcher.Core/AndroidDebugBridge.cs
+++ b/QuestPatcher.Core/AndroidDebugBridge.cs
@@ -211,11 +211,6 @@ namespace QuestPatcher.Core
             return (await ListPackages()).Where(packageId => !DefaultPackagePrefixes.Any(packageId.StartsWith)).ToList();
         }
 
-        public async Task<string> GetPackageVersion(string packageId)
-        {
-            return (await RunCommand($"shell dumpsys \"package {packageId} | grep versionName\"")).StandardOutput.Remove(0, 16).Trim();
-        }
-
         public async Task InstallApp(string apkPath)
         {
             await RunCommand($"install \"{apkPath}\"");


### PR DESCRIPTION
This pull request adds a `questpatcher.modded` permission to the APK, which can be quickly detected from the `adb shell dumpsys <package>` output to avoid downloading the APK from the quest.

If this permission is not found, QuestPatcher will fall back to pulling the APK, as previously patched APKs will not have the permission.

This may turn out to be a bad idea, as permissions aren't meant for arbitrary metadata.
However, I can't find any other easily-addable manifest options that I can detect via the dumpsys output.