### PR TITLE
Grant Storage Permissions After Installing the Patched APK

### DIFF
--- a/QuestPatcher.Core/Patching/PatchingManager.cs
+++ b/QuestPatcher.Core/Patching/PatchingManager.cs
@@ -642,6 +642,22 @@ namespace QuestPatcher.Core.Patching
             // Recreate the mod directories as they will not be present after the uninstall/backup restore
             await _modManager.CreateModDirectories();
 
+            if (_config.PatchingPermissions.ExternalFiles)
+            {
+                try
+                {
+                    Log.Information("Granting external storage permission");
+                    await _debugBridge.RunShellCommand($"pm grant {_config.AppId} android.permission.READ_EXTERNAL_STORAGE");
+                    await _debugBridge.RunShellCommand($"pm grant {_config.AppId} android.permission.WRITE_EXTERNAL_STORAGE");
+                    await _debugBridge.RunShellCommand($"appops set --uid {_config.AppId} MANAGE_EXTERNAL_STORAGE allow");
+                }
+                catch (Exception e)
+                {
+                    Log.Error(e, "Failed to grant external storage permission");
+                }
+            }
+            
+            
             Log.Information("Patching complete!");
             InstalledApp.IsModded = true;
             PatchingCompleted?.Invoke(this, EventArgs.Empty);


### PR DESCRIPTION
We can grant the necessary storage permissions via adb command right after we finish installing the patched APK. 
This will avoid the issue which sometimes permission is not asked when launching the game.

This also fixes the compatibility with v51 by granting the new storage permission introduced in Android 11. 
(tested with Beat Saber 1.28.0)