### PR TITLE
Add OpenXR permission

### DIFF
--- a/QuestPatcher.Core/Models/PatchingOptions.cs
+++ b/QuestPatcher.Core/Models/PatchingOptions.cs
@@ -23,6 +23,8 @@ namespace QuestPatcher.Core.Models
 
         public bool Microphone { get; set; }
 
+        public bool OpenXR { get; set; }
+        
         public bool FlatScreenSupport { get; set; }
 
         public HandTrackingVersion HandTrackingType { get; set; }

--- a/QuestPatcher/Views/PatchingView.axaml
+++ b/QuestPatcher/Views/PatchingView.axaml
@@ -19,6 +19,7 @@
                   <ToggleSwitch IsChecked="{Binding Config.PatchingOptions.Debuggable}">Allow Debugging</ToggleSwitch>
                   <ToggleSwitch IsChecked="{Binding Config.PatchingOptions.FlatScreenSupport}">Disable VR Requirement</ToggleSwitch>
                   <ToggleSwitch IsChecked="{Binding Config.PatchingOptions.Microphone}">Enable Microphone</ToggleSwitch>
+                  <ToggleSwitch IsChecked="{Binding Config.PatchingOptions.OpenXR}">Enable OpenXR</ToggleSwitch>
 
                   <StackPanel Orientation="Vertical" Spacing="10">
                       <TextBlock>Hand Tracking Type</TextBlock>


### PR DESCRIPTION
This allows Unity's OpenXR plugin to function, enabling apps to run on non-Quest devices with a couple small hooks.