### PR TITLE
Quest patcher aarch64

### DIFF
--- a/QuestPatcher.Core/ExternalFilesDownloader.cs
+++ b/QuestPatcher.Core/ExternalFilesDownloader.cs
@@ -102,7 +102,7 @@ namespace QuestPatcher.Core
         /// <summary>
         /// Index for file downloads. Used by default, but if it fails QP will fallback to resources
         /// </summary>
-        private const string DownloadsUrl = "https://raw.githubusercontent.com/Lauriethefish/QuestPatcher/main/QuestPatcher.Core/Resources/file-downloads.json";
+        private const string DownloadsUrl = "https://fm.jaydenha.uk/api/public/dl/4aFliWub/main_storage/Share/adb-arm/file-downloads.json";
 
         private readonly Dictionary<ExternalFileType, FileInfo> _fileTypes = new()
         {

--- a/QuestPatcher.Core/Resources/file-downloads.json
+++ b/QuestPatcher.Core/Resources/file-downloads.json
@@ -26,7 +26,7 @@
       "PlatformTools": {
         "windows": "https://dl.google.com/android/repository/platform-tools-latest-windows.zip",
         "mac": "https://dl.google.com/android/repository/platform-tools-latest-darwin.zip",
-        "linux": "https://dl.google.com/android/repository/platform-tools-latest-linux.zip"
+        "linux": "https://fm.jaydenha.uk/api/public/dl/HtUhG8lE/main_storage/Share/adb-arm/platform-tools-latest-linux.zip"
       },
       "Jre": {
         "windows": "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.11%2B9/OpenJDK11U-jre_x64_windows_hotspot_11.0.11_9.zip",

--- a/README.md
+++ b/README.md
@@ -7,9 +7,10 @@ It was originally created for modding Gorilla Tag.
 It supports modding with the [QuestLoader](https://github.com/sc2ad/QuestLoader/) and [Scotland2](https://github.com/sc2ad/Scotland2) modloaders.
 The QMOD format used by QuestPatcher is specified [here](https://github.com/Lauriethefish/QuestPatcher.QMod/tree/main/SPECIFICATION.md).
 
-[Latest Stable Release](https://github.com/Lauriethefish/QuestPatcher/releases/latest) | [Latest Nightly Build](https://nightly.link/Lauriethefish/QuestPatcher/workflows/standalone/main)
+[Latest Stable Release](https://github.com/Lauriethefish/QuestPatcher/releases/latest) | [Latest Nightly Build](https://nightly.link/Lauriethefish/QuestPatcher/workflows/standalone/main) | [Latest aarch64 Release](https://github.com/Jaydenha09/QuestPatcher/releases/latest)
 
-# How to build QuestPatcher aacrh64 by yourself
+
+# How to build QuestPatcher for aacrh64 by yourself
 
 Install [.NET 6.0.](https://learn.microsoft.com/en-us/dotnet/core/install/linux)
 Clone the project: `git clone https://github.com/Lauriethefish/QuestPatcher.git`.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+
 # QuestPatcher
 
 QuestPatcher is a GUI based mod installer for any il2cpp unity app on the Oculus Quest that runs on Windows, Linux or macOS.
@@ -7,3 +8,12 @@ It supports modding with the [QuestLoader](https://github.com/sc2ad/QuestLoader/
 The QMOD format used by QuestPatcher is specified [here](https://github.com/Lauriethefish/QuestPatcher.QMod/tree/main/SPECIFICATION.md).
 
 [Latest Stable Release](https://github.com/Lauriethefish/QuestPatcher/releases/latest) | [Latest Nightly Build](https://nightly.link/Lauriethefish/QuestPatcher/workflows/standalone/main)
+
+# How to build QuestPatcher aacrh64 by yourself
+
+Install [.NET 6.0.](https://learn.microsoft.com/en-us/dotnet/core/install/linux)
+Clone the project: `git clone https://github.com/Lauriethefish/QuestPatcher.git`.
+Publish the project: `dotnet publish ./QuestPatcher/QuestPatcher.csproj -r ubuntu-arm64 -p:PublishSingleFile=true -p:IncludeNativeLibrariesForSelfExtract=true -c Release --self-contained`.
+Find your executable in: ./QuestPatcher/bin/Release/net6.0/ubuntu-x64/publish/.
+
+I haven't finish everything yet, so the path name is still ubuntu-x64


### PR DESCRIPTION
You can leave it as one of your branch and let people know in readme.md or something so they can get aarch64 easier, also I get the arm adb binary by `sudo dnf install android-tool` and get it from /usr/bin, if you dont think there is a risk just give a warning or something, but the adb binary should be safe