### PR TITLE
allow patching with no mod loader

### DIFF
--- a/QuestPatcher.Core/InstallManager.cs
+++ b/QuestPatcher.Core/InstallManager.cs
@@ -103,6 +103,11 @@ namespace QuestPatcher.Core
                         Log.Information("APK is modded with Scotland2");
                         return ModLoader.Scotland2;
                     }
+                    else if (tag.ModloaderName.Equals("None", StringComparison.OrdinalIgnoreCase))
+                    {
+                        Log.Information("APK was modded with no mod loader");
+                        return ModLoader.None;
+                    }
                     else
                     {
                         Log.Warning("Unknown modloader found in APK: {ModloaderName}", tag.ModloaderName);

--- a/QuestPatcher.Core/Models/Modloader.cs
+++ b/QuestPatcher.Core/Models/Modloader.cs
@@ -14,6 +14,10 @@
         /// </summary>
         Scotland2,
         /// <summary>
+        /// No mod loader. Used if just editing things like permissions.
+        /// </summary>
+        None,
+        /// <summary>
         /// Some other modloader, that QuestPatcher doesn't know about.
         /// In this case, it will give you the option to patch the APK, although doing so may overwrite the existing modloader or not work at all.
         /// </summary>

--- a/QuestPatcher/Views/PatchingView.axaml
+++ b/QuestPatcher/Views/PatchingView.axaml
@@ -57,6 +57,7 @@
           <ComboBox SelectedIndex="{Binding Config.PatchingOptions.ModLoader}">
             <ComboBoxItem>QuestLoader</ComboBoxItem>
             <ComboBoxItem>Scotland2</ComboBoxItem>
+            <ComboBoxItem>None</ComboBoxItem>
           </ComboBox>
         </StackPanel>
         <Button Command="{Binding StartPatching}" HorizontalContentAlignment="Center" HorizontalAlignment="Center" VerticalContentAlignment="Center" FontSize="15" Padding="12">Patch my App!</Button>


### PR DESCRIPTION
Did this because I just wanted to add hand tracking permission to an APK which already had a mod loader without adding a new one. In my case the game was Bonelab with MelonLoader (would be nice if [LemonLoader](https://github.com/LemonLoader/MelonLoaderInstaller) was merged into QuestPatcher but that's a separate conversation...)