### PR TITLE
allow patching with no mod loader

### DIFF
--- a/QuestPatcher.Core/InstallManager.cs
+++ b/QuestPatcher.Core/InstallManager.cs
@@ -103,6 +103,11 @@ namespace QuestPatcher.Core
                         Log.Information("APK is modded with Scotland2");
                         return ModLoader.Scotland2;
                     }
+                    else if (tag.ModloaderName.Equals("None", StringComparison.OrdinalIgnoreCase))
+                    {
+                        Log.Information("APK is modded with no mod loader");
+                        return ModLoader.None;
+                    }
                     else
                     {
                         Log.Warning("Unknown modloader found in APK: {ModloaderName}", tag.ModloaderName);

--- a/QuestPatcher.Core/Models/Modloader.cs
+++ b/QuestPatcher.Core/Models/Modloader.cs
@@ -14,6 +14,10 @@
         /// </summary>
         Scotland2,
         /// <summary>
+        /// No mod loader. Used if just editing things like permissions.
+        /// </summary>
+        None,
+        /// <summary>
         /// Some other modloader, that QuestPatcher doesn't know about.
         /// In this case, it will give you the option to patch the APK, although doing so may overwrite the existing modloader or not work at all.
         /// </summary>

--- a/QuestPatcher.Core/Patching/PatchingManager.cs
+++ b/QuestPatcher.Core/Patching/PatchingManager.cs
@@ -456,16 +456,18 @@ namespace QuestPatcher.Core.Patching
         /// <summary>
         /// Makes the modifications to the APK to support mods.
         /// </summary>
-        /// <param name="mainPath">Path of the libmain file to replace</param>
+        /// <param name="mainPath">Path of the libmain file to replace or null if it should not be replaced</param>
         /// <param name="modloaderPath">Path of the libmodloader to replace, or null if no modloader needs to be stored within the APK</param>
         /// <param name="unityPath">Optionally, a path to a replacement libunity.so</param>
         /// <param name="libsDirectory">The directory where the SO files are stored in the APK</param>
         /// <param name="ovrPlatformSdkPath">Path to the OVR platform SDK ZIP, used for patching with flatscreen support. Must be non-null if flatscreen support is enabled.</param>
         /// <param name="apk">The APK to patch</param>
-        private async Task ModifyApk(string mainPath, string? modloaderPath, string? unityPath, string? ovrPlatformSdkPath, string libsDirectory, ApkZip apk)
+        private async Task ModifyApk(string? mainPath, string? modloaderPath, string? unityPath, string? ovrPlatformSdkPath, string libsDirectory, ApkZip apk)
         {
-            Log.Information("Copying libmain.so and libmodloader.so . . .");
-            await AddFileToApk(mainPath, Path.Combine(libsDirectory, "libmain.so"), apk);
+            if (mainPath != null) {
+                Log.Information("Copying libmain.so and libmodloader.so . . .");
+                await AddFileToApk(mainPath, Path.Combine(libsDirectory, "libmain.so"), apk);
+            }
             if (modloaderPath == null)
             {
                 if (apk.RemoveFile(Path.Combine(libsDirectory, "libmodloader.so")))
@@ -511,7 +513,10 @@ namespace QuestPatcher.Core.Patching
             Log.Information("Adding tag");
             using var tagStream = new MemoryStream();
 
-            string modloaderName = _config.PatchingOptions.ModLoader == ModLoader.QuestLoader ? "QuestLoader" : "Scotland2";
+            string modloaderName =
+                _config.PatchingOptions.ModLoader == ModLoader.QuestLoader ? "QuestLoader" :
+                _config.PatchingOptions.ModLoader == ModLoader.Scotland2 ? "Scotland2" :
+                "None";
             var tag = new ModdedTag("QuestPatcher", VersionUtil.QuestPatcherVersion.ToString(), modloaderName, null);
             JsonSerializer.Serialize(tagStream, tag, InstallManager.TagSerializerOptions);
             tagStream.Position = 0;
@@ -575,7 +580,9 @@ namespace QuestPatcher.Core.Patching
                 throw new NullReferenceException("Cannot patch before installed app has been checked");
             }
 
+            bool questLoader = _config.PatchingOptions.ModLoader == ModLoader.QuestLoader;
             bool scotland2 = _config.PatchingOptions.ModLoader == ModLoader.Scotland2;
+            bool noModLoader = _config.PatchingOptions.ModLoader == ModLoader.None;
 
             if (!InstalledApp.Is64Bit)
             {
@@ -584,7 +591,7 @@ namespace QuestPatcher.Core.Patching
                     Log.Error("App is 32 bit, cannot patch with scotland2");
                     throw new PatchingException("32 bit apps are not supported by scotland2");
                 }
-                else
+                else if (questLoader)
                 {
                     Log.Warning("App is 32 bit!");
                     if (!await _prompter.Prompt32Bit()) // Prompt the user to ask if they would like to continue, even though BS-hook doesn't work on 32 bit apps
@@ -594,7 +601,7 @@ namespace QuestPatcher.Core.Patching
                 }
             }
 
-            if (InstalledApp.ModLoader == ModLoader.Unknown)
+            if (InstalledApp.ModLoader == ModLoader.Unknown && !noModLoader)
             {
                 Log.Warning("APK contains unknown modloader");
                 if (!await _prompter.PromptUnknownModLoader())
@@ -608,8 +615,8 @@ namespace QuestPatcher.Core.Patching
 
             // First make sure that we have all necessary files downloaded, including the libmain and libmodloader
             string libsPath = InstalledApp.Is64Bit ? "lib/arm64-v8a" : "lib/armeabi-v7a";
-            string mainPath;
-            string? modloaderPath;
+            string? mainPath = null;
+            string? modloaderPath = null;
             string? ovrPlatformSdkPath = null;
 
             if (scotland2)
@@ -620,7 +627,7 @@ namespace QuestPatcher.Core.Patching
                 // Scotland2 itself lives outside the APK, so save it to the required location
                 await SaveScotland2(true); // As we patch the APK, we should update the sl2 version, in case some old version is breaking things
             }
-            else
+            else if (questLoader)
             {
 
                 if (InstalledApp.Is64Bit)

--- a/QuestPatcher/Resources/Strings.Designer.cs
+++ b/QuestPatcher/Resources/Strings.Designer.cs
@@ -602,6 +602,15 @@ namespace QuestPatcher.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to None.
+        /// </summary>
+        public static string ModLoader_None {
+            get {
+                return ResourceManager.GetString("ModLoader_None", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Choose a file type to manage:.
         /// </summary>
         public static string OtherItems_ChooseType {

--- a/QuestPatcher/Resources/Strings.resx
+++ b/QuestPatcher/Resources/Strings.resx
@@ -146,6 +146,9 @@ Make sure that your internet does not go offline during patching.</value>
     <data name="ModLoader_Scotland2" xml:space="preserve">
         <value>Scotland2</value>
     </data>
+    <data name="ModLoader_None" xml:space="preserve">
+        <value>None</value>
+    </data>
     <data name="Progress_Downloading" xml:space="preserve">
         <value>Downloading {0} . . .</value>
     </data>

--- a/QuestPatcher/Views/PatchingView.axaml
+++ b/QuestPatcher/Views/PatchingView.axaml
@@ -59,6 +59,7 @@
           <ComboBox SelectedIndex="{Binding Config.PatchingOptions.ModLoader}">
             <ComboBoxItem Content="{x:Static res:Strings.ModLoader_QuestLoader}"/>
             <ComboBoxItem Content="{x:Static res:Strings.ModLoader_Scotland2}"/>
+            <ComboBoxItem Content="{x:Static res:Strings.ModLoader_None}" />
           </ComboBox>
         </StackPanel>
         <Button Command="{Binding StartPatching}" HorizontalContentAlignment="Center" HorizontalAlignment="Center" VerticalContentAlignment="Center" FontSize="15" Padding="12" Content="{x:Static res:Strings.Patching_StartPatching}"/>

--- a/QuestPatcher/Views/RepatchWindow.axaml
+++ b/QuestPatcher/Views/RepatchWindow.axaml
@@ -25,6 +25,7 @@
           <ComboBox SelectedIndex="{Binding Config.PatchingOptions.ModLoader}" HorizontalAlignment="Center">
               <ComboBoxItem Content="{x:Static res:Strings.ModLoader_QuestLoader}"/>
               <ComboBoxItem Content="{x:Static res:Strings.ModLoader_Scotland2}"/>
+              <ComboBoxItem Content="{x:Static res:Strings.ModLoader_None}" />
           </ComboBox>
           <Button Content="{x:Static res:Strings.Repatch_StartRepatching}" Command="{Binding RepatchApp}" HorizontalAlignment="Center"/>
         </StackPanel>


### PR DESCRIPTION
Did this because I just wanted to add hand tracking permission to an APK which already had a mod loader without adding a new one. In my case the game was Bonelab with MelonLoader (would be nice if [LemonLoader](https://github.com/LemonLoader/MelonLoaderInstaller) was merged into QuestPatcher but that's a separate conversation...)